### PR TITLE
Add options to customize molecule drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,69 @@ from bokeh.plotting import show
 show(figure)
 ```
 
+## Styling the Molecule Structure
+
+The molecule structure which is shown when a data point is hovered over can be customised in two ways: by passing a
+style object to the `scatter` function or by using a custom function to render the SVG image containing the 2D 
+structure entirely.
+
+### Changing the molecule style
+
+The `scatter` function accepts a `molecule_style` argument which will control certain aspects of how the 2D
+structure will be rendered:
+
+```python
+from plotmol import MoleculeStyle
+
+molecule_style = MoleculeStyle(
+    image_width=200,
+    image_height=200,
+    
+    highlight_tagged_atoms=True,
+    highlight_tagged_bonds=True,
+)
+
+plotmol.scatter(
+    figure,
+    x=[0.0, 1.0, 2.0, 3.0],
+    y=[1.0, 2.0, 3.0, 4.0],
+    smiles=["C=O", "CC=O", "COC", "CCCO"],
+    molecule_style=molecule_style
+)
+```
+
+By default atoms which have been tagged with a map index, e.g. `"[C:1][C:2]"`, and the bonds between those atoms will
+be highlighted. This behaviour can be disabled by setting `highlight_tagged_atoms` and / or `highlight_tagged_bonds`
+to `False`.
+
+### Using a custom render function
+
+By default the 2D structure of the molecule associated with a data point is drawn using RDKit using the 
+``plotmol.utilities.rdkit.smiles_to_svg`` function, however an entirely custom function can be passed to
+the `scatter` function:
+
+```python
+
+def custom_image_function(smiles: str, style: MoleculeStyle) -> str:
+    
+    # Render the molecule to a SVG
+    svg_contents = ...
+    
+    return svg_contents
+
+plotmol.scatter(
+    figure,
+    x=[0.0, 1.0, 2.0, 3.0],
+    y=[1.0, 2.0, 3.0, 4.0],
+    smiles=["C=O", "CC=O", "COC", "CCCO"],
+    molecule_to_image_function=custom_image_function
+)
+
+```
+
+The function should take as arguments a SMILES pattern which defines the molecule that should be drawn, and a style
+object which specifies options for how the molecule should be drawn.
+
 ### Copyright
 
 Copyright (c) 2021, Simon Boothroyd

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The `scatter` function accepts a `molecule_style` argument which will control ce
 structure will be rendered:
 
 ```python
-from plotmol import MoleculeStyle
+from plotmol.styles import MoleculeStyle
 
 molecule_style = MoleculeStyle(
     image_width=200,

--- a/plotmol/__init__.py
+++ b/plotmol/__init__.py
@@ -5,8 +5,9 @@ Interactive plotting of data annotated with molecule structures.
 
 from ._version import get_versions
 from .plotmol import scatter
+from .styles import MoleculeStyle
 
-__all__ = [scatter]
+__all__ = [MoleculeStyle, scatter]
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/plotmol/__init__.py
+++ b/plotmol/__init__.py
@@ -5,9 +5,8 @@ Interactive plotting of data annotated with molecule structures.
 
 from ._version import get_versions
 from .plotmol import scatter
-from .styles import MoleculeStyle
 
-__all__ = [MoleculeStyle, scatter]
+__all__ = [scatter]
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/plotmol/plotmol.py
+++ b/plotmol/plotmol.py
@@ -1,14 +1,18 @@
 import base64
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from bokeh.models import ColumnDataSource
 from bokeh.plotting import Figure
 
+from plotmol import MoleculeStyle
 from plotmol.utilities.rdkit import smiles_to_svg
 
 DataType = Union[float, int, str]
+
 Label = Dict[str, str]
 Marker = Literal["x", "o"]
+
+MoleculeToImageFunction = Callable[[str, MoleculeStyle], str]
 
 
 class InputSizeError(ValueError):
@@ -44,6 +48,8 @@ def scatter(
     marker: Optional[str] = None,
     marker_size: Optional[int] = None,
     marker_color: Optional[str] = None,
+    molecule_style: Optional[MoleculeStyle] = None,
+    molecule_to_image_function: Optional[MoleculeToImageFunction] = None,
     **kwargs: Dict[str, Any],
 ):
     """Adds a scatter series to a bokeh figure which will show the molecular
@@ -58,9 +64,25 @@ def scatter(
         marker: The marker style.
         marker_size: The size of the marker to draw.
         marker_color: The marker color.
+        molecule_style: Options which control how the 2D structure which is shown when a
+            data point is hovered over should be rendered.
+        molecule_to_image_function: The function which should be used to render the
+            molecule as a 2D SVG image. This function should accept a string SMILES
+            pattern and a molecule style object and return a valid SVG string (e.g.
+            ``"<svg>...</svg>"``). By default the ``plotmol.rdkit.smiles_to_svg``
+            function will be used.
         kwargs: Extra keyword arguments to pass to the underlying bokeh ``scatter``
             function.
     """
+
+    # Set the default mutable inputs.
+    molecule_style = molecule_style if molecule_style is not None else MoleculeStyle()
+
+    molecule_to_image_function = (
+        molecule_to_image_function
+        if molecule_to_image_function is not None
+        else smiles_to_svg
+    )
 
     # Validate the sizes of the input arrays.
     data_sizes = {"x": len(x), "y": len(y), "smiles": len(smiles)}
@@ -70,7 +92,9 @@ def scatter(
 
     # Generate an image for each SMILES pattern.
     raw_images = [
-        base64.b64encode(smiles_to_svg(smiles_pattern).encode()).decode()
+        base64.b64encode(
+            molecule_to_image_function(smiles_pattern, molecule_style).encode()
+        ).decode()
         for smiles_pattern in smiles
     ]
     images = [f"data:image/svg+xml;base64,{raw_image}" for raw_image in raw_images]

--- a/plotmol/plotmol.py
+++ b/plotmol/plotmol.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Union
 from bokeh.models import ColumnDataSource
 from bokeh.plotting import Figure
 
-from plotmol import MoleculeStyle
+from plotmol.styles import MoleculeStyle
 from plotmol.utilities.rdkit import smiles_to_svg
 
 DataType = Union[float, int, str]

--- a/plotmol/styles.py
+++ b/plotmol/styles.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MoleculeStyle:
+    """Options to control the appearance of the 2D structure of the drawn molecule that
+    appears when a data point is hovered over.
+
+    Attributes:
+
+        image_width: The width [px] to make the image of the 2D structure.
+
+        image_height: The height [px] to make the image of the 2D structure.
+
+        highlight_tagged_atoms: Whether to highlight atoms which have been tagged with
+            a map index, e.g. whether the oxygen atom should be highlighted for
+            ``"C[O:1]"``.
+
+        highlight_tagged_bonds: Whether to highlight bonds between atoms which have
+            been tagged with a map index, e.g. whether the carbon-oxygen bond should be
+            highlighted for ``"[C:1][O:2]"``.
+
+    """
+
+    image_width: int = 200
+    image_height: int = 200
+
+    highlight_tagged_atoms: bool = True
+    highlight_tagged_bonds: bool = True

--- a/plotmol/tests/test_plotmol.py
+++ b/plotmol/tests/test_plotmol.py
@@ -1,7 +1,7 @@
 import pytest
 from bokeh.plotting import Figure
 
-from plotmol import plotmol
+from plotmol import MoleculeStyle, plotmol
 from plotmol.plotmol import InputSizeError, default_tooltip_template
 
 
@@ -43,3 +43,29 @@ def test_scatter_invalid_input_size(bokeh_figure):
 
     with pytest.raises(InputSizeError):
         plotmol.scatter(bokeh_figure, x=[0.0], y=[0.0, 1.0], smiles=["C", "CCO"])
+
+
+def test_scatter_custom_molecule_function(bokeh_figure):
+
+    function_called = False
+
+    def molecule_to_svg(smiles, style):
+
+        nonlocal function_called
+        function_called = True
+
+        assert smiles in ["C", "CCO"]
+        assert style.image_width == 1
+
+        return "</svg>"
+
+    plotmol.scatter(
+        bokeh_figure,
+        x=[0.0, 1.0],
+        y=[0.0, 1.0],
+        smiles=["C", "CCO"],
+        molecule_style=MoleculeStyle(image_width=1),
+        molecule_to_image_function=molecule_to_svg,
+    )
+
+    assert function_called is True

--- a/plotmol/tests/test_plotmol.py
+++ b/plotmol/tests/test_plotmol.py
@@ -1,8 +1,9 @@
 import pytest
 from bokeh.plotting import Figure
 
-from plotmol import MoleculeStyle, plotmol
+from plotmol import plotmol
 from plotmol.plotmol import InputSizeError, default_tooltip_template
+from plotmol.styles import MoleculeStyle
 
 
 @pytest.fixture()

--- a/plotmol/tests/utilities/test_rdkit.py
+++ b/plotmol/tests/utilities/test_rdkit.py
@@ -1,8 +1,9 @@
+from plotmol import MoleculeStyle
 from plotmol.utilities.rdkit import smiles_to_svg
 
 
 def test_smiles_to_svg():
     # It's difficult to test this as it's a graphical function. For now make sure
     # it doesn't error and something is produced.
-    output = smiles_to_svg("CO")
+    output = smiles_to_svg("CO", MoleculeStyle())
     assert len(output) > 0

--- a/plotmol/tests/utilities/test_rdkit.py
+++ b/plotmol/tests/utilities/test_rdkit.py
@@ -1,4 +1,4 @@
-from plotmol import MoleculeStyle
+from plotmol.styles import MoleculeStyle
 from plotmol.utilities.rdkit import smiles_to_svg
 
 

--- a/plotmol/utilities/rdkit.py
+++ b/plotmol/utilities/rdkit.py
@@ -3,9 +3,14 @@ import functools
 from rdkit import Chem
 from rdkit.Chem.Draw import rdMolDraw2D
 
+from plotmol import MoleculeStyle
+
 
 @functools.lru_cache(1024)
-def smiles_to_svg(smiles: str, image_width: int = 200, image_height: int = 200) -> str:
+def smiles_to_svg(
+    smiles: str,
+    style: MoleculeStyle,
+) -> str:
     """Renders a 2D representation of a molecule based on its SMILES representation as
     an SVG string.
 
@@ -13,10 +18,8 @@ def smiles_to_svg(smiles: str, image_width: int = 200, image_height: int = 200) 
     ----------
     smiles
         The SMILES pattern.
-    image_width
-        The width to make the final SVG.
-    image_height
-        The height to make the final SVG.
+    style
+        Options which control how the structure should be rendered as an image.
 
     Returns
     -------
@@ -30,17 +33,36 @@ def smiles_to_svg(smiles: str, image_width: int = 200, image_height: int = 200) 
     rdkit_molecule = Chem.MolFromSmiles(smiles, smiles_parser)
 
     # look for any tagged atom indices
-    tagged_atoms = [
-        atom.GetIdx() for atom in rdkit_molecule.GetAtoms() if atom.GetAtomMapNum() != 0
-    ]
+    tagged_atoms = (
+        []
+        if not style.highlight_tagged_atoms
+        else [
+            atom.GetIdx()
+            for atom in rdkit_molecule.GetAtoms()
+            if atom.GetAtomMapNum() != 0
+        ]
+    )
+    tagged_bonds = (
+        []
+        if not style.highlight_tagged_bonds
+        else [
+            bond.GetIdx()
+            for bond in rdkit_molecule.GetBonds()
+            if bond.GetBeginAtom().GetAtomMapNum() != 0
+            and bond.GetEndAtom().GetAtomMapNum() != 0
+        ]
+    )
 
     # Generate a set of 2D coordinates.
     if not rdkit_molecule.GetNumConformers():
         Chem.rdDepictor.Compute2DCoords(rdkit_molecule)
 
-    drawer = rdMolDraw2D.MolDraw2DSVG(image_width, image_height)
+    drawer = rdMolDraw2D.MolDraw2DSVG(style.image_width, style.image_height)
     rdMolDraw2D.PrepareAndDrawMolecule(
-        drawer, rdkit_molecule, highlightAtoms=tagged_atoms
+        drawer,
+        rdkit_molecule,
+        highlightAtoms=tagged_atoms,
+        highlightBonds=tagged_bonds,
     )
     drawer.FinishDrawing()
 

--- a/plotmol/utilities/rdkit.py
+++ b/plotmol/utilities/rdkit.py
@@ -3,7 +3,7 @@ import functools
 from rdkit import Chem
 from rdkit.Chem.Draw import rdMolDraw2D
 
-from plotmol import MoleculeStyle
+from plotmol.styles import MoleculeStyle
 
 
 @functools.lru_cache(1024)


### PR DESCRIPTION
## Description

This PR expands on #1 by adding a new `MoleculeStyle` object which can be passed to the `scatter` function to control how the 2D structure shown as a tooltip is rendered, as well as adding a `molecule_to_image_function` so that a completely custom render function can be used.

## Status
- [ ] Ready to go